### PR TITLE
Donations annotated with limited teams objects

### DIFF
--- a/jailbreak-api/src/main/java/org/jailbreak/api/representations/Representations.java
+++ b/jailbreak-api/src/main/java/org/jailbreak/api/representations/Representations.java
@@ -19132,6 +19132,19 @@ public final class Representations {
      */
     com.google.protobuf.ByteString
         getEmailBytes();
+
+    /**
+     * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+     */
+    boolean hasTeam();
+    /**
+     * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+     */
+    org.jailbreak.api.representations.Representations.Team getTeam();
+    /**
+     * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+     */
+    org.jailbreak.api.representations.Representations.TeamOrBuilder getTeamOrBuilder();
   }
   /**
    * Protobuf type {@code org.jailbreak.api.representations.Donation}
@@ -19226,6 +19239,19 @@ public final class Representations {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000040;
               email_ = bs;
+              break;
+            }
+            case 66: {
+              org.jailbreak.api.representations.Representations.Team.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000080) == 0x00000080)) {
+                subBuilder = team_.toBuilder();
+              }
+              team_ = input.readMessage(org.jailbreak.api.representations.Representations.Team.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(team_);
+                team_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000080;
               break;
             }
           }
@@ -20071,6 +20097,27 @@ public final class Representations {
       }
     }
 
+    public static final int TEAM_FIELD_NUMBER = 8;
+    private org.jailbreak.api.representations.Representations.Team team_;
+    /**
+     * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+     */
+    public boolean hasTeam() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+     */
+    public org.jailbreak.api.representations.Representations.Team getTeam() {
+      return team_;
+    }
+    /**
+     * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+     */
+    public org.jailbreak.api.representations.Representations.TeamOrBuilder getTeamOrBuilder() {
+      return team_;
+    }
+
     private void initFields() {
       id_ = 0;
       teamId_ = 0;
@@ -20079,6 +20126,7 @@ public final class Representations {
       time_ = 0L;
       type_ = org.jailbreak.api.representations.Representations.Donation.DonationType.OFFLINE;
       email_ = "";
+      team_ = org.jailbreak.api.representations.Representations.Team.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -20113,6 +20161,9 @@ public final class Representations {
       }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         output.writeBytes(7, getEmailBytes());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeMessage(8, team_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -20150,6 +20201,10 @@ public final class Representations {
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(7, getEmailBytes());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, team_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -20260,6 +20315,7 @@ public final class Representations {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getTeamFieldBuilder();
         }
       }
       private static Builder create() {
@@ -20282,6 +20338,12 @@ public final class Representations {
         bitField0_ = (bitField0_ & ~0x00000020);
         email_ = "";
         bitField0_ = (bitField0_ & ~0x00000040);
+        if (teamBuilder_ == null) {
+          team_ = org.jailbreak.api.representations.Representations.Team.getDefaultInstance();
+        } else {
+          teamBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
         return this;
       }
 
@@ -20338,6 +20400,14 @@ public final class Representations {
           to_bitField0_ |= 0x00000040;
         }
         result.email_ = email_;
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        if (teamBuilder_ == null) {
+          result.team_ = team_;
+        } else {
+          result.team_ = teamBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -20378,6 +20448,9 @@ public final class Representations {
           bitField0_ |= 0x00000040;
           email_ = other.email_;
           onChanged();
+        }
+        if (other.hasTeam()) {
+          mergeTeam(other.getTeam());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -20719,6 +20792,122 @@ public final class Representations {
         email_ = value;
         onChanged();
         return this;
+      }
+
+      private org.jailbreak.api.representations.Representations.Team team_ = org.jailbreak.api.representations.Representations.Team.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          org.jailbreak.api.representations.Representations.Team, org.jailbreak.api.representations.Representations.Team.Builder, org.jailbreak.api.representations.Representations.TeamOrBuilder> teamBuilder_;
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public boolean hasTeam() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public org.jailbreak.api.representations.Representations.Team getTeam() {
+        if (teamBuilder_ == null) {
+          return team_;
+        } else {
+          return teamBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public Builder setTeam(org.jailbreak.api.representations.Representations.Team value) {
+        if (teamBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          team_ = value;
+          onChanged();
+        } else {
+          teamBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public Builder setTeam(
+          org.jailbreak.api.representations.Representations.Team.Builder builderForValue) {
+        if (teamBuilder_ == null) {
+          team_ = builderForValue.build();
+          onChanged();
+        } else {
+          teamBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public Builder mergeTeam(org.jailbreak.api.representations.Representations.Team value) {
+        if (teamBuilder_ == null) {
+          if (((bitField0_ & 0x00000080) == 0x00000080) &&
+              team_ != org.jailbreak.api.representations.Representations.Team.getDefaultInstance()) {
+            team_ =
+              org.jailbreak.api.representations.Representations.Team.newBuilder(team_).mergeFrom(value).buildPartial();
+          } else {
+            team_ = value;
+          }
+          onChanged();
+        } else {
+          teamBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public Builder clearTeam() {
+        if (teamBuilder_ == null) {
+          team_ = org.jailbreak.api.representations.Representations.Team.getDefaultInstance();
+          onChanged();
+        } else {
+          teamBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
+        return this;
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public org.jailbreak.api.representations.Representations.Team.Builder getTeamBuilder() {
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return getTeamFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      public org.jailbreak.api.representations.Representations.TeamOrBuilder getTeamOrBuilder() {
+        if (teamBuilder_ != null) {
+          return teamBuilder_.getMessageOrBuilder();
+        } else {
+          return team_;
+        }
+      }
+      /**
+       * <code>optional .org.jailbreak.api.representations.Team team = 8;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          org.jailbreak.api.representations.Representations.Team, org.jailbreak.api.representations.Representations.Team.Builder, org.jailbreak.api.representations.Representations.TeamOrBuilder> 
+          getTeamFieldBuilder() {
+        if (teamBuilder_ == null) {
+          teamBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              org.jailbreak.api.representations.Representations.Team, org.jailbreak.api.representations.Representations.Team.Builder, org.jailbreak.api.representations.Representations.TeamOrBuilder>(
+                  getTeam(),
+                  getParentForChildren(),
+                  isClean());
+          team_ = null;
+        }
+        return teamBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:org.jailbreak.api.representations.Donation)
@@ -24995,33 +25184,34 @@ public final class Representations {
       "\t\022\022\n\nauthor_url\030\007 \001(\t\022\030\n\020author_photo_ur" +
       "l\030\010 \001(\t\022\014\n\004time\030\t \001(\003\022\017\n\007team_id\030\n \001(\005\0225" +
       "\n\004team\030\013 \001(\0132\'.org.jailbreak.api.represe" +
-      "ntations.Team\"\324\002\n\010Donation\022\n\n\002id\030\001 \001(\005\022\017",
+      "ntations.Team\"\213\003\n\010Donation\022\n\n\002id\030\001 \001(\005\022\017",
       "\n\007team_id\030\002 \001(\005\022\016\n\006amount\030\003 \001(\005\022\014\n\004name\030" +
       "\004 \001(\t\022\014\n\004time\030\005 \001(\003\022F\n\004type\030\006 \001(\01628.org." +
       "jailbreak.api.representations.Donation.D" +
-      "onationType\022\r\n\005email\030\007 \001(\t\032\177\n\020DonationsF" +
-      "ilters\022\017\n\007team_id\030\001 \001(\005\022\022\n\nsince_time\030\002 " +
-      "\001(\003\022F\n\004type\030\003 \001(\01628.org.jailbreak.api.re" +
-      "presentations.Donation.DonationType\"\'\n\014D" +
-      "onationType\022\013\n\007OFFLINE\020\000\022\n\n\006ONLINE\020\001\"r\n\023" +
-      "StripeChargeRequest\022\r\n\005token\030\001 \001(\t\022\016\n\006am" +
-      "ount\030\002 \001(\005\022\017\n\007team_id\030\003 \001(\005\022\r\n\005email\030\004 \001",
-      "(\t\022\014\n\004name\030\005 \001(\t\022\016\n\006backer\030\006 \001(\010\":\n\021Face" +
-      "bookAuthToken\022\024\n\014access_token\030\001 \001(\t\022\017\n\007u" +
-      "ser_id\030\002 \001(\003\"?\n\010ApiToken\022\021\n\tapi_token\030\001 " +
-      "\001(\t\022\017\n\007user_id\030\002 \001(\003\022\017\n\007expires\030\003 \001(\003\"\247\003" +
-      "\n\004User\022\017\n\007user_id\030\001 \001(\003\022\024\n\014time_created\030" +
-      "\002 \001(\003\022E\n\nuser_level\030\003 \001(\01621.org.jailbrea" +
-      "k.api.representations.User.UserLevel\022\r\n\005" +
-      "email\030\004 \001(\t\022\022\n\nfirst_name\030\005 \001(\t\022\021\n\tlast_" +
-      "name\030\006 \001(\t\022>\n\006gender\030\007 \001(\0162..org.jailbre" +
-      "ak.api.representations.User.Gender\022\020\n\010ti",
-      "mezone\030\010 \001(\005\022\016\n\006locale\030\t \001(\t\022\025\n\rfacebook" +
-      "_link\030\n \001(\t\022\026\n\016api_tokens_url\030\013 \001(\t\"?\n\tU" +
-      "serLevel\022\016\n\nSUPERADMIN\020\000\022\t\n\005ADMIN\020\001\022\013\n\007T" +
-      "RACKER\020\002\022\n\n\006NORMAL\020\003\")\n\006Gender\022\010\n\004MALE\020\000" +
-      "\022\n\n\006FEMALE\020\001\022\t\n\005OTHER\020\002B\021B\017Representatio" +
-      "ns"
+      "onationType\022\r\n\005email\030\007 \001(\t\0225\n\004team\030\010 \001(\013" +
+      "2\'.org.jailbreak.api.representations.Tea" +
+      "m\032\177\n\020DonationsFilters\022\017\n\007team_id\030\001 \001(\005\022\022" +
+      "\n\nsince_time\030\002 \001(\003\022F\n\004type\030\003 \001(\01628.org.j" +
+      "ailbreak.api.representations.Donation.Do" +
+      "nationType\"\'\n\014DonationType\022\013\n\007OFFLINE\020\000\022" +
+      "\n\n\006ONLINE\020\001\"r\n\023StripeChargeRequest\022\r\n\005to",
+      "ken\030\001 \001(\t\022\016\n\006amount\030\002 \001(\005\022\017\n\007team_id\030\003 \001" +
+      "(\005\022\r\n\005email\030\004 \001(\t\022\014\n\004name\030\005 \001(\t\022\016\n\006backe" +
+      "r\030\006 \001(\010\":\n\021FacebookAuthToken\022\024\n\014access_t" +
+      "oken\030\001 \001(\t\022\017\n\007user_id\030\002 \001(\003\"?\n\010ApiToken\022" +
+      "\021\n\tapi_token\030\001 \001(\t\022\017\n\007user_id\030\002 \001(\003\022\017\n\007e" +
+      "xpires\030\003 \001(\003\"\247\003\n\004User\022\017\n\007user_id\030\001 \001(\003\022\024" +
+      "\n\014time_created\030\002 \001(\003\022E\n\nuser_level\030\003 \001(\016" +
+      "21.org.jailbreak.api.representations.Use" +
+      "r.UserLevel\022\r\n\005email\030\004 \001(\t\022\022\n\nfirst_name" +
+      "\030\005 \001(\t\022\021\n\tlast_name\030\006 \001(\t\022>\n\006gender\030\007 \001(",
+      "\0162..org.jailbreak.api.representations.Us" +
+      "er.Gender\022\020\n\010timezone\030\010 \001(\005\022\016\n\006locale\030\t " +
+      "\001(\t\022\025\n\rfacebook_link\030\n \001(\t\022\026\n\016api_tokens" +
+      "_url\030\013 \001(\t\"?\n\tUserLevel\022\016\n\nSUPERADMIN\020\000\022" +
+      "\t\n\005ADMIN\020\001\022\013\n\007TRACKER\020\002\022\n\n\006NORMAL\020\003\")\n\006G" +
+      "ender\022\010\n\004MALE\020\000\022\n\n\006FEMALE\020\001\022\t\n\005OTHER\020\002B\021" +
+      "B\017Representations"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -25118,7 +25308,7 @@ public final class Representations {
     internal_static_org_jailbreak_api_representations_Donation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_jailbreak_api_representations_Donation_descriptor,
-        new java.lang.String[] { "Id", "TeamId", "Amount", "Name", "Time", "Type", "Email", });
+        new java.lang.String[] { "Id", "TeamId", "Amount", "Name", "Time", "Type", "Email", "Team", });
     internal_static_org_jailbreak_api_representations_Donation_DonationsFilters_descriptor =
       internal_static_org_jailbreak_api_representations_Donation_descriptor.getNestedTypes().get(0);
     internal_static_org_jailbreak_api_representations_Donation_DonationsFilters_fieldAccessorTable = new

--- a/jailbreak-api/src/main/resources/representations.proto
+++ b/jailbreak-api/src/main/resources/representations.proto
@@ -208,6 +208,7 @@ message Donation {
 	optional int64 time = 5;
 	optional DonationType type = 6;
 	optional string email = 7;
+	optional Team team = 8;
 }
 
 message StripeChargeRequest {

--- a/jailbreak-service/src/main/java/org/jailbreak/service/base/CheckinsManagerImpl.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/base/CheckinsManagerImpl.java
@@ -1,6 +1,8 @@
 package org.jailbreak.service.base;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 import org.jailbreak.api.representations.Representations.Checkin;
 import org.jailbreak.service.core.CheckinsManager;
@@ -9,6 +11,7 @@ import org.jailbreak.service.helpers.DistanceHelper;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
 public class CheckinsManagerImpl implements CheckinsManager {
@@ -45,8 +48,15 @@ public class CheckinsManagerImpl implements CheckinsManager {
 	}
 	
 	@Override
-	public List<Checkin> getCheckins(List<Integer> ids) {
-		return this.addDistanceToX(this.dao.getCheckins(ids));
+	public HashMap<Integer, Checkin> getCheckins(Set<Integer> ids) {
+		List<Checkin> checkins = this.addDistanceToX(this.dao.getCheckins(ids));
+		
+		HashMap<Integer, Checkin> map = Maps.newHashMap();
+		for (Checkin checkin : checkins) {
+			map.put(checkin.getId(), checkin);
+		}
+		
+		return map;
 	}
 	
 	@Override

--- a/jailbreak-service/src/main/java/org/jailbreak/service/core/CheckinsManager.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/core/CheckinsManager.java
@@ -1,6 +1,8 @@
 package org.jailbreak.service.core;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 import org.jailbreak.api.representations.Representations.Checkin;
 
@@ -12,7 +14,7 @@ public interface CheckinsManager {
 	Optional<Checkin> updateCheckin(Checkin checkin);
 	
 	Optional<Checkin> getCheckin(int id);
-	List<Checkin> getCheckins(List<Integer> ids);
+	HashMap<Integer, Checkin> getCheckins(Set<Integer> ids);
 	
 	Optional<Checkin> getTeamCheckin(int teamId, int id);
 	Optional<Checkin> getLastTeamCheckin(int teamId);

--- a/jailbreak-service/src/main/java/org/jailbreak/service/core/TeamsManager.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/core/TeamsManager.java
@@ -1,6 +1,8 @@
 package org.jailbreak.service.core;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 import org.jailbreak.api.representations.Representations.Team;
 import org.jailbreak.api.representations.Representations.Team.TeamsFilters;
@@ -12,9 +14,11 @@ public interface TeamsManager {
 	public Optional<Team> getRawTeam(int id);
 	public Optional<Team> getTeam(int id);
 	public Optional<Team> getTeamSlug(String slug);
+	public Optional<Team> getLimitedTeam(int id);
 	
 	public List<Team> getTeams();
 	public List<Team> getTeams(int limit, TeamsFilters filters);
+	public HashMap<Integer, Team> getLimitedTeams(Set<Integer> ids);
 	
 	public Team addTeam(Team team);
 	public Optional<Team> updateTeam(Team team);

--- a/jailbreak-service/src/main/java/org/jailbreak/service/db/BindIds.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/db/BindIds.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 import java.sql.Array;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.List;
+import java.util.Set;
 
 import org.skife.jdbi.v2.SQLStatement;
 import org.skife.jdbi.v2.sqlobject.Binder;
@@ -23,8 +23,8 @@ public @interface BindIds {
 		
 		@SuppressWarnings("rawtypes")
 		public Binder build(Annotation annotation) {
-			return new Binder<BindIds, List<Integer>>() {
-				public void bind(SQLStatement<?> q, BindIds bind, List<Integer> ids) {
+			return new Binder<BindIds, Set<Integer>>() {
+				public void bind(SQLStatement<?> q, BindIds bind, Set<Integer> ids) {
 					Array idsArray;
 					try {
 						// it is extremely important that we bind in 

--- a/jailbreak-service/src/main/java/org/jailbreak/service/db/CheckinsDAO.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/db/CheckinsDAO.java
@@ -1,6 +1,7 @@
 package org.jailbreak.service.db;
 
 import java.util.List;
+import java.util.Set;
 
 import org.jailbreak.api.representations.Representations.Checkin;
 import org.jailbreak.service.db.mappers.CheckinsMapper;
@@ -28,7 +29,7 @@ public interface CheckinsDAO {
 	Optional<Checkin> getCheckin(@Bind("id") int id);
 	
 	@SqlQuery("SELECT *, position[0] as x, position[1] as y FROM checkins WHERE id = ANY (:idList)")
-	List<Checkin> getCheckins(@BindIds List<Integer> ids);
+	List<Checkin> getCheckins(@BindIds Set<Integer> ids);
 	
 	@SqlQuery("SELECT *, position[0] as x, position[1] as y FROM checkins WHERE team_id = :team_id AND id = :id")
 	@SingleValueResult(Checkin.class)

--- a/jailbreak-service/src/main/java/org/jailbreak/service/db/TeamsDAO.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/db/TeamsDAO.java
@@ -41,12 +41,12 @@ public abstract class TeamsDAO {
 	@SqlQuery("SELECT * FROM teams WHERE id = :id")
 	@SingleValueResult(Team.class)
 	public abstract Optional<Team> getTeam(@Bind("id") int id);
-			
-	@SqlQuery("SELECT id, team_number, team_name, names, slug, avatar, tag_line, university, amount_raised_online, amount_raised_offline, countries, transports, featured, position FROM teams WHERE id = :id")
+	
+	@SqlQuery("SELECT id, team_number, team_name, names, slug, avatar, tag_line, university, amount_raised_online, amount_raised_offline, countries, transports, featured, last_checkin_id FROM teams WHERE id = :id")
 	@SingleValueResult(Team.class)
 	public abstract Optional<Team> getLimitedTeam(@Bind("id") int id);
 	
-	@SqlQuery("SELECT id, team_number, team_name, names, slug, avatar, tag_line, university, amount_raised_online, amount_raised_offline, countries, transports, featured, position FROM teams WHERE id = ANY (:idList)")
+	@SqlQuery("SELECT id, team_number, team_name, names, slug, avatar, tag_line, university, amount_raised_online, amount_raised_offline, countries, transports, featured, last_checkin_id FROM teams WHERE id = ANY (:idList)")
 	@SingleValueResult(Team.class)
 	public abstract List<Team> getLimitedTeams(@BindIds Set<Integer> ids);
 	

--- a/jailbreak-service/src/main/java/org/jailbreak/service/db/TeamsDAO.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/db/TeamsDAO.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jailbreak.api.representations.Representations.Team;
 import org.jailbreak.api.representations.Representations.Team.TeamsFilters;
@@ -40,6 +41,14 @@ public abstract class TeamsDAO {
 	@SqlQuery("SELECT * FROM teams WHERE id = :id")
 	@SingleValueResult(Team.class)
 	public abstract Optional<Team> getTeam(@Bind("id") int id);
+			
+	@SqlQuery("SELECT id, team_number, team_name, names, slug, avatar, tag_line, university, amount_raised_online, amount_raised_offline, countries, transports, featured, position FROM teams WHERE id = :id")
+	@SingleValueResult(Team.class)
+	public abstract Optional<Team> getLimitedTeam(@Bind("id") int id);
+	
+	@SqlQuery("SELECT id, team_number, team_name, names, slug, avatar, tag_line, university, amount_raised_online, amount_raised_offline, countries, transports, featured, position FROM teams WHERE id = ANY (:idList)")
+	@SingleValueResult(Team.class)
+	public abstract List<Team> getLimitedTeams(@BindIds Set<Integer> ids);
 	
 	@SqlQuery("SELECT * FROM teams WHERE slug = :slug")
 	@SingleValueResult(Team.class)

--- a/jailbreak-service/src/main/java/org/jailbreak/service/db/mappers/TeamsMapper.java
+++ b/jailbreak-service/src/main/java/org/jailbreak/service/db/mappers/TeamsMapper.java
@@ -7,10 +7,15 @@ import org.jailbreak.api.representations.Representations.Team;
 import org.jailbreak.api.representations.Representations.Team.University;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TeamsMapper implements ResultSetMapper<Team> {
 	
+	private final Logger LOG = LoggerFactory.getLogger(TeamsMapper.class);
+	
 	public Team map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+		// Limited Team Object Attributes
 		int id = r.getInt("id");
 		int team_number = r.getInt("team_number");
 		String team_name = r.getString("team_name");
@@ -22,11 +27,8 @@ public class TeamsMapper implements ResultSetMapper<Team> {
 		int amountRaisedOffline = r.getInt("amount_raised_offline");
 		int countries = r.getInt("countries");
 		int transports = r.getInt("transports");
-		String description = r.getString("description");
 		boolean featured = r.getBoolean("featured");
 		String slug = r.getString("slug");
-		String video = r.getString("video");
-		String avatarLarge = r.getString("avatar_large");
 		int lastCheckinId = r.getInt("last_checkin_id");
 		
 		Team.Builder builder = Team.newBuilder()
@@ -54,17 +56,35 @@ public class TeamsMapper implements ResultSetMapper<Team> {
 			builder.setAvatar(avatar);
 		}
 		
-		if (description != null && !description.isEmpty()) {
-			builder.setDescription(description);
+		
+		// Full Team Object Attributes
+		boolean fullTeam = true;
+		try {
+			// simple test that will fail on the limited team object result set
+			r.getString("description");
+		} catch (SQLException e) {
+			// Burying SQLException because we maybe trying to map a limited team instead of a full team
+			fullTeam = false;
 		}
 		
-		if (video != null && !video.isEmpty()) {
-			builder.setVideo(video);
+		if (fullTeam) {
+			String description = r.getString("description");
+			String video = r.getString("video");
+			String avatarLarge = r.getString("avatar_large");
+			
+			if (description != null && !description.isEmpty()) {
+				builder.setDescription(description);
+			}
+			
+			if (video != null && !video.isEmpty()) {
+				builder.setVideo(video);
+			}
+			
+			if (avatarLarge != null && !avatarLarge.isEmpty()) {
+				builder.setAvatarLarge(avatarLarge);
+			}
 		}
 		
-		if (avatarLarge != null && !avatarLarge.isEmpty()) {
-			builder.setAvatarLarge(avatarLarge);
-		}
 		
 		return builder.build();
 	}


### PR DESCRIPTION
- Added logic for get limited team objects by single id or list of ids.
- Changed the annotation pattern so there is less type confusion
- The list id queries now accept Sets of ids instead of lists to be sure we are free of duplicates
- Donation objects are now annotated with the limited team object (Note to self: update API docs)
